### PR TITLE
Fixed logging of namespace and name

### DIFF
--- a/cmd/opencensus-operator/main.go
+++ b/cmd/opencensus-operator/main.go
@@ -150,13 +150,13 @@ func (cmd *autoconfCmd) autoconf(req *admission.AdmissionRequest) *admission.Adm
 		shouldConfigure = b
 	} else {
 		log.Printf("Invalid value %q for annotation %s on pod %s/%s, continuing with default",
-			pod.Annotations[annotationConfigure], annotationConfigure, pod.Namespace, pod.Name)
+			pod.Annotations[annotationConfigure], annotationConfigure, namespace, name)
 	}
 	if !shouldConfigure {
 		return &admission.AdmissionResponse{Allowed: true}
 	}
 
-	log.Printf("configuring pod %s/%s", pod.Namespace, pod.Name)
+	log.Printf("configuring pod %s/%s", namespace, name)
 
 	patch, err := createPatch(cmd.clusterName, namespace, name, &pod)
 	if err != nil {


### PR DESCRIPTION
Use the derived values for these fields. `pod.Namespace` and `pod.Name` could be empty, as per the block of code above.

@rghetia could you please review?