### PR TITLE
Use a distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM  quay.io/prometheus/busybox:latest
+FROM  gcr.io/distroless/static:latest
 LABEL maintainer "Stackdriver Engineering <engineering@stackdriver.com>"
 
 COPY opencensus-operator /bin/opencensus-operator
 
-USER       nobody
 EXPOSE     9091
 ENTRYPOINT [ "/bin/opencensus-operator" ]
-


### PR DESCRIPTION
Removes potential for security vulnerabilities.